### PR TITLE
Remove unnecessary else case in with

### DIFF
--- a/lib/cldr/unit.ex
+++ b/lib/cldr/unit.ex
@@ -79,8 +79,6 @@ defmodule Cldr.Unit do
       {:ok, unit} <- verify_unit(locale, style, unit)
     do
       {:ok, to_string(number, unit, locale, style, options)}
-    else
-      {:error, reason} -> {:error, reason}
     end
   end
 


### PR DESCRIPTION
It'll be returned anyways, so no need to handle it in an `else` case.