### PR TITLE
fix(Cldr.Unit.compare): Units built from Decimal string value are not compared corrrectly

### DIFF
--- a/lib/cldr/unit/math.ex
+++ b/lib/cldr/unit/math.ex
@@ -518,11 +518,7 @@ defmodule Cldr.Unit.Math do
   end
 
   def compare(%Unit{unit: unit} = unit_1, %Unit{unit: unit} = unit_2) do
-    cond do
-      unit_1.value == unit_2.value -> :eq
-      unit_1.value > unit_2.value -> :gt
-      unit_1.value < unit_2.value -> :lt
-    end
+    Ratio.compare(Ratio.new(unit_1.value), Ratio.new(unit_2.value))
   end
 
   def compare(%Unit{} = unit_1, %Unit{} = unit_2) do

--- a/test/conversion_test.exs
+++ b/test/conversion_test.exs
@@ -62,6 +62,12 @@ defmodule Cldr.Unit.Conversion.Test do
     end
   end
 
+  test "compare/2 for [Decimal] units that are built from string" do
+    s_unit = Cldr.Unit.new!(Decimal.new("300.0"), "gram")
+    t_unit = Cldr.Unit.new!(Decimal.new("60.0"), "kilogram")
+    assert Cldr.Unit.compare(s_unit, t_unit) == :lt
+  end
+
   test "convert!/2" do
     assert MyApp.Cldr.Unit.convert!(MyApp.Cldr.Unit.new!(:foot, 3), :meter)
 


### PR DESCRIPTION
The PR fixes the issue `Cldr.Unit.compare` does not correctly evaluate units that are created from `Decimal` that is defined from string instead of integer. 

Instead of doing a simple comparison of Decimal value, which does a string comparison for above, now it relies on `Ratio.compare/2` that is more generic and accurate.