### PR TITLE
split_into_units: Don't break for SI prefixes only

### DIFF
--- a/lib/cldr/unit/parser.ex
+++ b/lib/cldr/unit/parser.ex
@@ -347,7 +347,7 @@ defmodule Cldr.Unit.Parser do
   end
 
   for {prefix, _scale} <- Prefix.si_factors() do
-    def split_into_units(<<unquote(prefix), rest::binary>>) do
+    def split_into_units(<<unquote(prefix), rest::binary>>) when byte_size(rest) > 0 do
       [head | rest] = split_into_units(rest)
       [unquote(prefix) <> head | rest]
     end

--- a/test/cldr_units_test.exs
+++ b/test/cldr_units_test.exs
@@ -251,6 +251,11 @@ defmodule Cldr.UnitsTest do
               {Cldr.Unit.UnitNotTranslatableError, "The unit \"milliliter\" is not translatable"}}
   end
 
+  test "validate unit does not break for SI prefixes only" do
+    assert Cldr.Unit.validate_unit("milli") ==
+             {:error, {Cldr.UnknownUnitError, "Unknown unit was detected at \"milli\""}}
+  end
+
   test "Unit of 1 retrieves a default pattern is plural category pattern does not exist" do
     unit = Cldr.Unit.new!(1, :pascal)
     assert Cldr.Unit.to_string(unit, locale: "de", style: :short) == {:ok, "1 Pa"}


### PR DESCRIPTION
Fixes #46