### PR TITLE
Fix documentation warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,3 +106,7 @@ jobs:
     # Step: Execute dialyzer.
     - name: Run dialyzer
       run: mix dialyzer
+
+    # Step: Execute `mix docs`
+    - name: Validate documentation
+      run: mix docs --warnings-as-errors

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The primary api is defined by three functions:
 
 * `MyApp.Cldr.Unit.convert/2` to convert one compatible unit to another
 
-* `MyApp.Cldr.Unit.localize/3` to localize a unit by converting it to units customary for a given territory
+* `MyApp.Cldr.Unit.localize/2` to localize a unit by converting it to units customary for a given territory
 
 * `MyApp.Cldr.Unit.add/2`, `MyApp.Cldr.Unit.sub/2`, `MyApp.Cldr.Unit.mult/2`, `MyApp.Cldr.Unit.div/2` provide basic arithmetic operations on compatible `Unit.t` structs.
 
@@ -260,13 +260,13 @@ See `Cldr.Unit.preferred_units/3` to see what mappings are available, in particu
 Basic arithmetic is provided by `Cldr.Unit.add/2`, `Cldr.Unit.sub/2`, `Cldr.Unit.mult/2`, `Cldr.Unit.div/2` as well as `Cldr.Unit.round/3`
 
 ```elixir
-iex> Cldr.Unit.Math.add Cldr.Unit.new!(:foot, 1), Cldr.Unit.new!(:foot, 1)
+iex> Cldr.Unit.add Cldr.Unit.new!(:foot, 1), Cldr.Unit.new!(:foot, 1)
 #Cldr.Unit<:foot, 2>
 
-iex> Cldr.Unit.Math.add Cldr.Unit.new!(:foot, 1), Cldr.Unit.new!(:mile, 1)
+iex> Cldr.Unit.add Cldr.Unit.new!(:foot, 1), Cldr.Unit.new!(:mile, 1)
 #Cldr.Unit<:foot, 5280.945925937846>
 
-iex> Cldr.Unit.Math.add Cldr.Unit.new!(:foot, 1), Cldr.Unit.new!(:gallon, 1)
+iex> Cldr.Unit.add Cldr.Unit.new!(:foot, 1), Cldr.Unit.new!(:gallon, 1)
 {:error, {Cldr.Unit.IncompatibleUnitError,
  "Operations can only be performed between units of the same type. Received #Cldr.Unit<:foot, 1> and #Cldr.Unit<:gallon, 1>"}}
 

--- a/lib/cldr/unit.ex
+++ b/lib/cldr/unit.ex
@@ -52,20 +52,304 @@ defmodule Cldr.Unit do
   defdelegate preferred_units(unit, backend, options), to: Preference
   defdelegate preferred_units!(unit, backend, options), to: Preference
 
+  @doc """
+  Adds two compatible `t:Cldr.Unit.t/0` types
+
+  ## Arguments
+
+  * `unit_1` and `unit_2` are compatible Units
+    returned by `Cldr.Unit.new/2`.
+
+  ## Returns
+
+  * A `t:Cldr.Unit.t/0` of the same type as `unit_1` with a value
+    that is the sum of `unit_1` and the potentially converted
+    `unit_2`, or
+
+  * `{:error, {IncompatibleUnitError, message}}`.
+
+  ## Examples
+
+      iex> Cldr.Unit.add Cldr.Unit.new!(:foot, 1), Cldr.Unit.new!(:foot, 1)
+      Cldr.Unit.new!(:foot, 2)
+
+      iex> Cldr.Unit.add Cldr.Unit.new!(:foot, 1), Cldr.Unit.new!(:mile, 1)
+      Cldr.Unit.new!(:foot, 5281)
+
+      iex> Cldr.Unit.add Cldr.Unit.new!(:foot, 1), Cldr.Unit.new!(:gallon, 1)
+      {:error, {Cldr.Unit.IncompatibleUnitsError,
+        "Operations can only be performed between units with the same base unit. Received :foot and :gallon"}}
+
+  """
   defdelegate add(unit_1, unit_2), to: Math
+
+  @doc """
+  Subtracts two compatible `t:Cldr.Unit.t/0` types.
+
+  ## Arguments
+
+  * `unit_1` and `unit_2` are compatible Units
+    returned by `Cldr.Unit.new/2`.
+
+  ## Returns
+
+  * A `t:Cldr.Unit.t/0` of the same type as `unit_1` with a value
+    that is the difference between `unit_1` and the potentially
+    converted `unit_2`, or
+
+  * `{:error, {IncompatibleUnitError, message}}`.
+
+  ## Examples
+
+      iex> Cldr.Unit.sub Cldr.Unit.new!(:kilogram, 5), Cldr.Unit.new!(:pound, 1)
+      Cldr.Unit.new!(:kilogram, "4.54640763")
+
+      iex> Cldr.Unit.sub Cldr.Unit.new!(:pint, 5), Cldr.Unit.new!(:liter, 1)
+      Cldr.Unit.new!(:pint, "2.886623581134812676960800627")
+
+      iex> Cldr.Unit.sub Cldr.Unit.new!(:pint, 5), Cldr.Unit.new!(:pint, 1)
+      Cldr.Unit.new!(:pint, 4)
+
+  """
   defdelegate sub(unit_1, unit_2), to: Math
+
+  @doc """
+  Multiplies any two `t:Cldr.Unit.t/0` types or a `t:Cldr.Unit.t/0`
+  and a scalar.
+
+  ## Arguments
+
+  * `unit_1` is a unit
+    returned by `Cldr.Unit.new/2`.
+
+  * `unit_2` is a unit
+    returned by `Cldr.Unit.new/2` or
+    a number or Decimal.
+
+  ## Returns
+
+  * A `t:Cldr.Unit.t/0` of a type that is the product
+    of `unit_1` and `unit_2` with a value
+    that is the product of `unit_1` and `unit_2`'s
+    values.
+
+  ## Examples
+
+      iex> Cldr.Unit.mult Cldr.Unit.new!(:kilogram, 5), Cldr.Unit.new!(:pound, 1)
+      Cldr.Unit.new!(:kilogram, "2.26796185")
+
+      iex> Cldr.Unit.mult Cldr.Unit.new!(:pint, 5), Cldr.Unit.new!(:liter, 1)
+      Cldr.Unit.new!(:pint, "10.56688209432593661519599687")
+
+      iex> Cldr.Unit.mult Cldr.Unit.new!(:pint, 5), Cldr.Unit.new!(:pint, 1)
+      Cldr.Unit.new!(:pint, 5)
+
+  """
   defdelegate mult(unit_1, unit_2), to: Math
+
+  @doc """
+  Divides any `t:Cldr.Unit.t/0` type into another or a
+  number into a `t:Cldr.Unit.t/0`.
+
+  ## Options
+
+  * `unit_1` is a unit
+    returned by `Cldr.Unit.new/2`.
+
+  * `unit_2` is a unit
+    returned by `Cldr.Unit.new/2` or
+    a number or Decimal.
+
+  ## Returns
+
+  * A `t:Cldr.Unit.t/0` of a type that is the dividend
+    of `unit_1` and `unit_2` with a value
+    that is the dividend of `unit_1` and `unit_2`'s
+    values.
+
+  ## Examples
+
+      iex> Cldr.Unit.Math.div Cldr.Unit.new!(:kilogram, 5), Cldr.Unit.new!(:pound, 1)
+      Cldr.Unit.new!(:kilogram, "11.02311310924387903614869007")
+
+      iex> Cldr.Unit.Math.div Cldr.Unit.new!(:pint, 5), Cldr.Unit.new!(:liter, 1)
+      Cldr.Unit.new!(:pint, "2.365882365000000000000000000")
+
+      iex> Cldr.Unit.Math.div Cldr.Unit.new!(:pint, 5), Cldr.Unit.new!(:pint, 1)
+      Cldr.Unit.new!(:pint, 5)
+
+  """
   defdelegate div(unit_1, unit_2), to: Math
 
+  @doc """
+  Adds two compatible `t:Cldr.Unit.t/0` types
+  and raises on error.
+
+  ## Arguments
+
+  * `unit_1` and `unit_2` are compatible Units
+    returned by `Cldr.Unit.new/2`.
+
+  ## Returns
+
+  * A `t:Cldr.Unit.t/0` of the same type as `unit_1` with a value
+    that is the sum of `unit_1` and the potentially converted
+    `unit_2` or
+
+  * Raises an exception.
+
+  """
   defdelegate add!(unit_1, unit_2), to: Math
+
+  @doc """
+  Subtracts two compatible `t:Cldr.Unit.t/0` types
+  and raises on error.
+
+  ## Arguments
+
+  * `unit_1` and `unit_2` are compatible Units
+    returned by `Cldr.Unit.new/2`.
+
+  ## Returns
+
+  * A `t:Cldr.Unit.t/0` of the same type as `unit_1` with a value
+    that is the difference between `unit_1` and the potentially
+    converted `unit_2` or
+
+  * Raises an exception.
+
+  """
   defdelegate sub!(unit_1, unit_2), to: Math
+
+  @doc """
+  Multiplies two compatible `t:Cldr.Unit.t/0` types
+  and raises on error.
+
+  ## Options
+
+  * `unit_1` is a unit
+    returned by `Cldr.Unit.new/2`.
+
+  * `unit_2` is a unit
+    returned by `Cldr.Unit.new/2` or
+    a number or Decimal.
+
+  ## Returns
+
+  * A `t:Cldr.Unit.t/0` of the same type as `unit_1` with a value
+    that is the product of `unit_1` and the potentially
+    converted `unit_2` or
+
+  * Raises an exception.
+
+  """
   defdelegate mult!(unit_1, unit_2), to: Math
+
+  @doc """
+  Divides one `t:Cldr.Unit.t/0` type into another.
+  Any unit can be divided by another.
+
+  ## Arguments
+
+  * `unit_1` is a unit
+    returned by `Cldr.Unit.new/2`.
+
+  * `unit_2` is a unit
+    returned by `Cldr.Unit.new/2` or
+    a number or Decimal.
+
+  ## Returns
+
+  * A `t:Cldr.Unit.t/0` of the same type as `unit_1` with a value
+    that is the dividend of `unit_1` and the potentially
+    converted `unit_2` or
+
+  * Raises an exception.
+
+  """
   defdelegate div!(unit_1, unit_2), to: Math
 
-  defdelegate round(unit, places, mode), to: Math
-  defdelegate round(unit, places), to: Math
-  defdelegate round(unit), to: Math
+  @doc """
+  Rounds the value of a unit.
 
+  ## Arguments
+
+  * `unit` is any unit returned by `Cldr.Unit.new/2`
+
+  * `places` is the number of decimal places to round to.
+    The default is `0`.
+
+  * `mode` is the rounding mode to be applied.  The default
+    is `:half_up`.
+
+  ## Returns
+
+  * A `%Unit{}` of the same type as `unit` with a value
+    that is rounded to the specified number of decimal places.
+
+  ## Rounding modes
+
+  Directed roundings:
+
+  * `:down` - Round towards 0 (truncate), eg 10.9 rounds to 10.0
+
+  * `:up` - Round away from 0, eg 10.1 rounds to 11.0. (Non IEEE algorithm)
+
+  * `:ceiling` - Round toward +∞ - Also known as rounding up or ceiling
+
+  * `:floor` - Round toward -∞ - Also known as rounding down or floor
+
+  Round to nearest:
+
+  * `:half_even` - Round to nearest value, but in a tiebreak, round towards the
+    nearest value with an even (zero) least significant bit, which occurs 50%
+    of the time. This is the default for IEEE binary floating-point and the recommended
+    value for decimal.
+
+  * `:half_up` - Round to nearest value, but in a tiebreak, round away from 0.
+    This is the default algorithm for Erlang's Kernel.round/2
+
+  * `:half_down` - Round to nearest value, but in a tiebreak, round towards 0
+    (Non IEEE algorithm)
+
+  ## Examples
+
+      iex> Cldr.Unit.round Cldr.Unit.new!(:yard, 1031.61), 1
+      Cldr.Unit.new!(:yard, "1031.6")
+
+      iex> Cldr.Unit.round Cldr.Unit.new!(:yard, 1031.61), 2
+      Cldr.Unit.new!(:yard, "1031.61")
+
+      iex> Cldr.Unit.round Cldr.Unit.new!(:yard, 1031.61), 1, :up
+      Cldr.Unit.new!(:yard, "1031.7")
+
+  """
+  defdelegate round(unit, places, mode), to: Math
+
+  @doc delegate_to: {Cldr.Unit, :round, 3}
+  def round(unit, places), do: Math.round(unit, places)
+
+  @doc delegate_to: {Cldr.Unit, :round, 3}
+  def round(unit), do: Math.round(unit)
+
+  @doc """
+  Compare two units, converting to a common unit
+  type if required.
+
+  If conversion is performed, the results are both
+  rounded to a single decimal place before
+  comparison.
+
+  Returns `:gt`, `:lt`, or `:eq`.
+
+  ## Example
+
+      iex> x = Cldr.Unit.new!(:kilometer, 1)
+      iex> y = Cldr.Unit.new!(:meter, 1000)
+      iex> Cldr.Unit.Math.compare x, y
+      :eq
+
+  """
   defdelegate compare(unit_1, unit_2), to: Math
 
   @root_locale_name Cldr.Config.root_locale_name()

--- a/lib/cldr/unit.ex
+++ b/lib/cldr/unit.ex
@@ -10,8 +10,9 @@ defmodule Cldr.Unit do
 
   * `Cldr.Unit.known_units/0` identifies the available units for localization
 
-  * `Cldr.Unit.{add, sub, mult, div}/2` to support basic unit mathematics between
-    units of compatible type (like length or volume)
+  * `Cldr.Unit.add/2`, `Cldr.Unit.sub/2`, `Cldr.Unit.mult/2`, `Cldr.Unit.div/2`
+    to support basic unit mathematics between units of compatible type (like
+    length or volume)
 
   * `Cldr.Unit.compare/2` to compare one unit to another unit as long as they
     are convertible.

--- a/lib/cldr/unit/backend.ex
+++ b/lib/cldr/unit/backend.ex
@@ -84,19 +84,19 @@ defmodule Cldr.Unit.Backend do
         defdelegate validate_style(unit), to: Cldr.Unit
         defdelegate unit_category(unit), to: Cldr.Unit
 
-        defdelegate add(unit_1, unit_2), to: Cldr.Unit.Math
-        defdelegate sub(unit_1, unit_2), to: Cldr.Unit.Math
-        defdelegate mult(unit_1, unit_2), to: Cldr.Unit.Math
-        defdelegate div(unit_1, unit_2), to: Cldr.Unit.Math
+        defdelegate add(unit_1, unit_2), to: Cldr.Unit
+        defdelegate sub(unit_1, unit_2), to: Cldr.Unit
+        defdelegate mult(unit_1, unit_2), to: Cldr.Unit
+        defdelegate div(unit_1, unit_2), to: Cldr.Unit
 
-        defdelegate add!(unit_1, unit_2), to: Cldr.Unit.Math
-        defdelegate sub!(unit_1, unit_2), to: Cldr.Unit.Math
-        defdelegate mult!(unit_1, unit_2), to: Cldr.Unit.Math
-        defdelegate div!(unit_1, unit_2), to: Cldr.Unit.Math
+        defdelegate add!(unit_1, unit_2), to: Cldr.Unit
+        defdelegate sub!(unit_1, unit_2), to: Cldr.Unit
+        defdelegate mult!(unit_1, unit_2), to: Cldr.Unit
+        defdelegate div!(unit_1, unit_2), to: Cldr.Unit
 
-        defdelegate round(unit, places, mode), to: Cldr.Unit.Math
-        defdelegate round(unit, places), to: Cldr.Unit.Math
-        defdelegate round(unit), to: Cldr.Unit.Math
+        defdelegate round(unit, places, mode), to: Cldr.Unit
+        defdelegate round(unit, places), to: Cldr.Unit
+        defdelegate round(unit), to: Cldr.Unit
 
         defdelegate convert(unit_1, to_unit), to: Cldr.Unit.Conversion
         defdelegate convert!(unit_1, to_unit), to: Cldr.Unit.Conversion

--- a/lib/cldr/unit/math.ex
+++ b/lib/cldr/unit/math.ex
@@ -18,35 +18,6 @@ defmodule Cldr.Unit.Math do
   @doc false
   defguard is_simple_unit(base_conversion) when is_list(base_conversion)
 
-  @doc """
-  Adds two compatible `t:Cldr.Unit.t/0` types
-
-  ## Arguments
-
-  * `unit_1` and `unit_2` are compatible Units
-    returned by `Cldr.Unit.new/2`.
-
-  ## Returns
-
-  * A `t:Cldr.Unit.t/0` of the same type as `unit_1` with a value
-    that is the sum of `unit_1` and the potentially converted
-    `unit_2`, or
-
-  * `{:error, {IncompatibleUnitError, message}}`.
-
-  ## Examples
-
-      iex> Cldr.Unit.Math.add Cldr.Unit.new!(:foot, 1), Cldr.Unit.new!(:foot, 1)
-      Cldr.Unit.new!(:foot, 2)
-
-      iex> Cldr.Unit.Math.add Cldr.Unit.new!(:foot, 1), Cldr.Unit.new!(:mile, 1)
-      Cldr.Unit.new!(:foot, 5281)
-
-      iex> Cldr.Unit.Math.add Cldr.Unit.new!(:foot, 1), Cldr.Unit.new!(:gallon, 1)
-      {:error, {Cldr.Unit.IncompatibleUnitsError,
-        "Operations can only be performed between units with the same base unit. Received :foot and :gallon"}}
-
-  """
   @spec add(Unit.t(), Unit.t()) :: Unit.t() | {:error, {module(), String.t()}}
 
   def add(%Unit{unit: unit, value: value_1} = unit_1, %Unit{unit: unit, value: value_2}) do
@@ -63,24 +34,6 @@ defmodule Cldr.Unit.Math do
     end
   end
 
-  @doc """
-  Adds two compatible `t:Cldr.Unit.t/0` types
-  and raises on error.
-
-  ## Arguments
-
-  * `unit_1` and `unit_2` are compatible Units
-    returned by `Cldr.Unit.new/2`.
-
-  ## Returns
-
-  * A `t:Cldr.Unit.t/0` of the same type as `unit_1` with a value
-    that is the sum of `unit_1` and the potentially converted
-    `unit_2` or
-
-  * Raises an exception.
-
-  """
   @spec add!(Unit.t(), Unit.t()) :: Unit.t() | no_return()
 
   def add!(unit_1, unit_2) do
@@ -90,34 +43,6 @@ defmodule Cldr.Unit.Math do
     end
   end
 
-  @doc """
-  Subtracts two compatible `t:Cldr.Unit.t/0` types.
-
-  ## Arguments
-
-  * `unit_1` and `unit_2` are compatible Units
-    returned by `Cldr.Unit.new/2`.
-
-  ## Returns
-
-  * A `t:Cldr.Unit.t/0` of the same type as `unit_1` with a value
-    that is the difference between `unit_1` and the potentially
-    converted `unit_2`, or
-
-  * `{:error, {IncompatibleUnitError, message}}`.
-
-  ## Examples
-
-      iex> Cldr.Unit.sub Cldr.Unit.new!(:kilogram, 5), Cldr.Unit.new!(:pound, 1)
-      Cldr.Unit.new!(:kilogram, "4.54640763")
-
-      iex> Cldr.Unit.sub Cldr.Unit.new!(:pint, 5), Cldr.Unit.new!(:liter, 1)
-      Cldr.Unit.new!(:pint, "2.886623581134812676960800627")
-
-      iex> Cldr.Unit.sub Cldr.Unit.new!(:pint, 5), Cldr.Unit.new!(:pint, 1)
-      Cldr.Unit.new!(:pint, 4)
-
-  """
   @spec sub(Unit.t(), Unit.t()) :: Unit.t() | {:error, {module(), String.t()}}
 
   def sub(%Unit{unit: unit, value: value_1} = unit_1, %Unit{unit: unit, value: value_2}) do
@@ -134,24 +59,6 @@ defmodule Cldr.Unit.Math do
     end
   end
 
-  @doc """
-  Subtracts two compatible `t:Cldr.Unit.t/0` types
-  and raises on error.
-
-  ## Arguments
-
-  * `unit_1` and `unit_2` are compatible Units
-    returned by `Cldr.Unit.new/2`.
-
-  ## Returns
-
-  * A `t:Cldr.Unit.t/0` of the same type as `unit_1` with a value
-    that is the difference between `unit_1` and the potentially
-    converted `unit_2` or
-
-  * Raises an exception.
-
-  """
   @spec sub!(Unit.t(), Unit.t()) :: Unit.t() | no_return()
 
   def sub!(unit_1, unit_2) do
@@ -161,38 +68,6 @@ defmodule Cldr.Unit.Math do
     end
   end
 
-  @doc """
-  Multiplies any two `t:Cldr.Unit.t/0` types or a t:Cldr.Unit.t/0`
-  and a scalar.
-
-  ## Arguments
-
-  * `unit_1` is a unit
-    returned by `Cldr.Unit.new/2`.
-
-  * `unit_2` is a unit
-    returned by `Cldr.Unit.new/2` or
-    a number or Decimal.
-
-  ## Returns
-
-  * A `t:Cldr.Unit.t/0` of a type that is the product
-    of `unit_1` and `unit_2` with a value
-    that is the product of `unit_1` and `unit_2`'s
-    values.
-
-  ## Examples
-
-      iex> Cldr.Unit.mult Cldr.Unit.new!(:kilogram, 5), Cldr.Unit.new!(:pound, 1)
-      Cldr.Unit.new!(:kilogram, "2.26796185")
-
-      iex> Cldr.Unit.mult Cldr.Unit.new!(:pint, 5), Cldr.Unit.new!(:liter, 1)
-      Cldr.Unit.new!(:pint, "10.56688209432593661519599687")
-
-      iex> Cldr.Unit.mult Cldr.Unit.new!(:pint, 5), Cldr.Unit.new!(:pint, 1)
-      Cldr.Unit.new!(:pint, 5)
-
-  """
   @spec mult(Unit.t(), Unit.t()) ::
       Unit.t() | {:error, {module(), String.t()}}
 
@@ -221,67 +96,12 @@ defmodule Cldr.Unit.Math do
     end
   end
 
-
-  @doc """
-  Multiplies two compatible `t:Cldr.Unit.t/0` types
-  and raises on error.
-
-  ## Options
-
-  * `unit_1` is a unit
-    returned by `Cldr.Unit.new/2`.
-
-  * `unit_2` is a unit
-    returned by `Cldr.Unit.new/2` or
-    a number or Decimal.
-
-  ## Returns
-
-  * A `t:Cldr.Unit.t/0` of the same type as `unit_1` with a value
-    that is the product of `unit_1` and the potentially
-    converted `unit_2` or
-
-  * Raises an exception.
-
-  """
   @spec mult!(Unit.t(), Unit.t()) :: Unit.t() | {:error, {module(), String.t()}}
 
   def mult!(unit_1, unit_2) do
     mult(unit_1, unit_2)
   end
 
-  @doc """
-  Divides any `t:Cldr.Unit.t/0` type into another or a
-  number into a `t:Cldr.Unit.t/0`.
-
-  ## Options
-
-  * `unit_1` is a unit
-    returned by `Cldr.Unit.new/2`.
-
-  * `unit_2` is a unit
-    returned by `Cldr.Unit.new/2` or
-    a number or Decimal.
-
-  ## Returns
-
-  * A `t:Cldr.Unit.t/0` of a type that is the dividend
-    of `unit_1` and `unit_2` with a value
-    that is the dividend of `unit_1` and `unit_2`'s
-    values.
-
-  ## Examples
-
-      iex> Cldr.Unit.Math.div Cldr.Unit.new!(:kilogram, 5), Cldr.Unit.new!(:pound, 1)
-      Cldr.Unit.new!(:kilogram, "11.02311310924387903614869007")
-
-      iex> Cldr.Unit.Math.div Cldr.Unit.new!(:pint, 5), Cldr.Unit.new!(:liter, 1)
-      Cldr.Unit.new!(:pint, "2.365882365000000000000000000")
-
-      iex> Cldr.Unit.Math.div Cldr.Unit.new!(:pint, 5), Cldr.Unit.new!(:pint, 1)
-      Cldr.Unit.new!(:pint, 5)
-
-  """
   @spec div(Unit.t(), Unit.t()) ::
       Unit.t() | {:error, {module(), String.t()}}
 
@@ -309,89 +129,12 @@ defmodule Cldr.Unit.Math do
     end
   end
 
-  @doc """
-  Divides one `t:Cldr.Unit.t/0` type into another.
-  Any unit can be divided by another.
-
-  ## Arguments
-
-  * `unit_1` is a unit
-    returned by `Cldr.Unit.new/2`.
-
-  * `unit_2` is a unit
-    returned by `Cldr.Unit.new/2` or
-    a number or Decimal.
-
-  ## Returns
-
-  * A `t:Cldr.Unit.t/0` of the same type as `unit_1` with a value
-    that is the dividend of `unit_1` and the potentially
-    converted `unit_2` or
-
-  * Raises an exception.
-
-  """
   @spec div!(Unit.t(), Unit.t()) :: Unit.t() | {:error, {module(), String.t()}}
 
   def div!(unit_1, unit_2) do
     div(unit_1, unit_2)
   end
 
-  @doc """
-  Rounds the value of a unit.
-
-  ## Arguments
-
-  * `unit` is any unit returned by `Cldr.Unit.new/2`
-
-  * `places` is the number of decimal places to round to.
-    The default is `0`.
-
-  * `mode` is the rounding mode to be applied.  The default
-    is `:half_up`.
-
-  ## Returns
-
-  * A `%Unit{}` of the same type as `unit` with a value
-    that is rounded to the specified number of decimal places.
-
-  ## Rounding modes
-
-  Directed roundings:
-
-  * `:down` - Round towards 0 (truncate), eg 10.9 rounds to 10.0
-
-  * `:up` - Round away from 0, eg 10.1 rounds to 11.0. (Non IEEE algorithm)
-
-  * `:ceiling` - Round toward +∞ - Also known as rounding up or ceiling
-
-  * `:floor` - Round toward -∞ - Also known as rounding down or floor
-
-  Round to nearest:
-
-  * `:half_even` - Round to nearest value, but in a tiebreak, round towards the
-    nearest value with an even (zero) least significant bit, which occurs 50%
-    of the time. This is the default for IEEE binary floating-point and the recommended
-    value for decimal.
-
-  * `:half_up` - Round to nearest value, but in a tiebreak, round away from 0.
-    This is the default algorithm for Erlang's Kernel.round/2
-
-  * `:half_down` - Round to nearest value, but in a tiebreak, round towards 0
-    (Non IEEE algorithm)
-
-  ## Examples
-
-      iex> Cldr.Unit.round Cldr.Unit.new!(:yard, 1031.61), 1
-      Cldr.Unit.new!(:yard, "1031.6")
-
-      iex> Cldr.Unit.round Cldr.Unit.new!(:yard, 1031.61), 2
-      Cldr.Unit.new!(:yard, "1031.61")
-
-      iex> Cldr.Unit.round Cldr.Unit.new!(:yard, 1031.61), 1, :up
-      Cldr.Unit.new!(:yard, "1031.7")
-
-  """
   @spec round(
           unit :: Unit.t() | number() | Decimal.t(),
           places :: non_neg_integer,
@@ -444,24 +187,6 @@ defmodule Cldr.Unit.Math do
     %{unit | value: trunc}
   end
 
-  @doc """
-  Compare two units, converting to a common unit
-  type if required.
-
-  If conversion is performed, the results are both
-  rounded to a single decimal place before
-  comparison.
-
-  Returns `:gt`, `:lt`, or `:eq`.
-
-  ## Example
-
-      iex> x = Cldr.Unit.new!(:kilometer, 1)
-      iex> y = Cldr.Unit.new!(:meter, 1000)
-      iex> Cldr.Unit.Math.compare x, y
-      :eq
-
-  """
   @spec compare(unit_1 :: Unit.t(), unit_2 :: Unit.t()) :: :eq | :lt | :gt
 
   def compare(


### PR DESCRIPTION
This PR fixes documentation errors.

The first commit replaces the string `Cldr.Unit.{add, sub, mult, div}/2` with `Cldr.Unit.add/2`, `Cldr.Unit.sub/2`, `Cldr.Unit.mult/2`, `Cldr.Unit.div/2` since the former is not supported and creates warnings when running `mix docs`.

The second commit fixes some stuff in README.md. It was referencing localize/3 which does not exist. I assume it should say localize/3 instead. Similarly, it referenced Unit.Math.add, but there are no docs for Unit.math, so this creates warnings when creating documentation and doesn't insert a link.

Third commit moves function docs from Unit.Math to Unit. The documentation for the `Unit.Math` module is hidden, so all this documentation is never shown anywhere. It also generates invalid links from e.g. `Unit.add/2` to `Unit.Math.add/2` and gives warnings when compiling the documentation.

The fourth commit point defdelegates in backend.ex to Cldr.Unit instead of Cldr.Unit.Math. This removes the last warnings

The fifth commit (which I am happy to remove if you don't want it) adds `mix test --warnings-as-errors` to the CI, hopefully ensuring that errors like these won't show up in the future. 

