### PR TITLE
Fixes application name typo in exclude_protocol_implementation

### DIFF
--- a/lib/cldr/unit.ex
+++ b/lib/cldr/unit.ex
@@ -3222,7 +3222,7 @@ defmodule Cldr.Unit do
   @doc false
   def exclude_protocol_implementation(module) do
     exclusions =
-      :ex_unit
+      :ex_cldr_units
       |> Application.get_env(:exclude_protocol_implementations, [])
       |> List.wrap()
 


### PR DESCRIPTION
Hello,

There is a typo in the exclude_protocol_implementation application name.
It's set to `:ex_unit` rather than `:ex_cldr_units` making it impossible to set a configuration like so:

```elixir
config :ex_cldr_units,
  default_backend: MyApp.Cldr,
  exclude_protocol_implementations: [Phoenix.HTML.Safe]
```

Maybe it's done on purpose but here the fix if it's not the case.